### PR TITLE
Fixed HomeAssistant IP & Token not updating to "None"

### DIFF
--- a/Miles-V2/renderer.js
+++ b/Miles-V2/renderer.js
@@ -354,6 +354,13 @@ ipcRenderer.on('initialize-setup', () => {
 function saveApiKeys(apiKeys) {
     // Example of how apiKeys might be used or stored
     console.log('API Keys:', apiKeys);
+    
+    // Check if the Home Assistant URL and token are not provided
+    if (!setupValues['dynamic-textbox-home-assistant-url'] || !setupValues['dynamic-textbox-home-assistant-token']) {
+        // Set Home Assistant URL and token to "none" if not provided
+        setupValues['dynamic-textbox-home-assistant-url'] = 'none';
+        setupValues['dynamic-textbox-home-assistant-token'] = 'none';
+    }
 
     // Signal the main process to save API keys
     ipcRenderer.send('saveApiKeys', setupValues);


### PR DESCRIPTION
In this updated version of the saveApiKeys function:

Before sending the setupValues to the main process, we check if the dynamic-textbox-home-assistant-url and dynamic-textbox-home-assistant-token values are not provided (i.e., they are empty or falsy).

If either the Home Assistant URL or token is not provided, we set their values in the setupValues object to "none".

Finally, we send the updated setupValues object to the main process using ipcRenderer.send('saveApiKeys', setupValues) to save the API keys.

With this modification, if the user skips the Home Assistant setup step (i.e., clicks the "no-home-assistant" button), the HomeAssistant_URL_IP and HomeAssistant_Token values in the apikey.py file will be set to "none".